### PR TITLE
innerHTML → innerText

### DIFF
--- a/public/keycode.html
+++ b/public/keycode.html
@@ -70,7 +70,7 @@ async function ipl_ready(){
 		let n='['+ev.key+']';
 		if(l>0)n+='-'+l;
 		ktd[k].User.loc[l]=n;
-		ktd[k].Element.innerHTML=Object.values(ktd[k].User.loc).toString();
+		ktd[k].Element.innerText=Object.values(ktd[k].User.loc).toString();
 	};
 	document.onkeyup=(ev)=>{
 		if(ev.isComposing)return;
@@ -85,7 +85,7 @@ async function ipl_ready(){
 			return;
 		}
 		delete ktd[k].User.loc[l];
-		ktd[k].Element.innerHTML=Object.values(ktd[k].User.loc).toString();
+		ktd[k].Element.innerText=Object.values(ktd[k].User.loc).toString();
 	};
 }
 //--></script></div></body></html>

--- a/public/yges/ipl.js
+++ b/public/yges/ipl.js
@@ -1659,7 +1659,7 @@ YgEs.ToQHT=(el)=>{
 		},
 		Clear:()=>{
 			if(!qht.Element)return;
-			qht.Element.innerHTML='';
+			qht.Element.innerText='';
 		},
 		Append:(src)=>{
 			if(!qht.Element)return;
@@ -1668,11 +1668,11 @@ YgEs.ToQHT=(el)=>{
 				if(src._yges_qht_)qht.Element.append(src.Element);
 				else qht.Element.append(src);
 			}
-			else qht.Element.innerHTML+=src;
+			else qht.Element.append(src);
 		},
 		Replace:(src)=>{
 			if(!qht.Element)return;
-			qht.Element.innerHTML='';
+			qht.Element.innerText='';
 			qht.Append(src);
 		},
 	}
@@ -1702,7 +1702,7 @@ YgEs.NewQHT=(prm)=>{
 				if(t._yges_qht_)el.append(t.Element);
 				else el.append(t);
 			}
-			else el.innerHTML+=t;
+			else el.append(t);
 		}
 	}
 	if(prm.Target)prm.Target.Append(el);

--- a/public/yges/qht.js
+++ b/public/yges/qht.js
@@ -20,7 +20,7 @@ YgEs.ToQHT=(el)=>{
 		},
 		Clear:()=>{
 			if(!qht.Element)return;
-			qht.Element.innerHTML='';
+			qht.Element.innerText='';
 		},
 		Append:(src)=>{
 			if(!qht.Element)return;
@@ -29,11 +29,11 @@ YgEs.ToQHT=(el)=>{
 				if(src._yges_qht_)qht.Element.append(src.Element);
 				else qht.Element.append(src);
 			}
-			else qht.Element.innerHTML+=src;
+			else qht.Element.append(src);
 		},
 		Replace:(src)=>{
 			if(!qht.Element)return;
-			qht.Element.innerHTML='';
+			qht.Element.innerText='';
 			qht.Append(src);
 		},
 	}
@@ -63,7 +63,7 @@ YgEs.NewQHT=(prm)=>{
 				if(t._yges_qht_)el.append(t.Element);
 				else el.append(t);
 			}
-			else el.innerHTML+=t;
+			else el.append(t);
 		}
 	}
 	if(prm.Target)prm.Target.Append(el);


### PR DESCRIPTION
close #18

QHTに対するHTML書き込みは受け付けないものとする。  
どうしても必要であれば、サニタイズを済ませた上で Element .innerHTML より行う。   
