### PR TITLE
Agent異常遷移コールバック追加

### DIFF
--- a/doxy/classes/agent_manager.md
+++ b/doxy/classes/agent_manager.md
@@ -33,7 +33,10 @@ user defined object kept in an agent
 | OnOpen | func<@ref pg_class_agent> | on open from cleaned up |
 | OnReady | func<@ref pg_class_agent> | on opening completed |
 | OnPollInHealthy | func<@ref pg_class_agent> | in polling after ready in cleaned up |
+| OnTrouble | func<@ref pg_class_agent> | happening from healthy |
 | OnPollInTrouble | func<@ref pg_class_agent> | in polling after ready during happening |
+| OnHalt | func<@ref pg_class_agent> | more happening from trouble |
+| OnRecover | func<@ref pg_class_agent> | resolved all happenings in trouble,halt |
 | OnClose | func<@ref pg_class_agent> | on close from ready |
 | OnBack | func<@ref pg_class_agent> | on close from opening unsatisfactory |
 | User | @ref Agent_UserShared? | share on created @ref pg_class_agent |

--- a/public/yges/agent.js
+++ b/public/yges/agent.js
@@ -250,6 +250,19 @@ function _standby(prm){
 			},
 		},
 		'TROUBLE':{
+			OnStart:(ctrl,user)=>{
+				try{
+					if(prm.OnTrouble)prm.OnTrouble(agent);
+				}
+				catch(e){
+					happen.HappenProp({
+						Class:'YgEs.AgentError',
+						Cause:'throw from a callback',
+						Src:GetInfo('OnTrouble'),
+						Err:YgEs.FromError(e),
+					});
+				}
+			},
 			OnPollInKeep:(ctrl,user)=>{
 				if(opencount<1 || restart){
 					ready=false;
@@ -267,16 +280,43 @@ function _standby(prm){
 					happen.HappenProp({
 							Class:'YgEs.AgentError',
 							Cause:'throw from a callback',
+						Src:GetInfo('OnPollInTrouble'),
+						Err:YgEs.FromError(e),
+					});
+					return 'HALT';
+				}
+			},
+			OnEnd:(ctrl,user)=>{
+				if(ctrl.GetNextState()=='HEALTHY'){
+					try{
+						if(prm.OnRecover)prm.OnRecover(agent);
+					}
+					catch(e){
+						happen.HappenProp({
+							Class:'YgEs.AgentError',
+							Cause:'throw from a callback',
 							Src:GetInfo('OnRecover'),
 							Err:YgEs.FromError(e),
 					});
-					return 'HALT';
+					}
 				}
 			},
 		},
 		'HALT':{
 			OnStart:(ctrl,user)=>{
 				halt=true;
+
+				try{
+					if(prm.OnHalt)prm.OnHalt(agent);
+				}
+				catch(e){
+					happen.HappenProp({
+						Class:'YgEs.AgentError',
+						Cause:'throw from a callback',
+						Src:GetInfo('OnHalt'),
+						Err:YgEs.FromError(e),
+					});
+				}
 			},
 			OnPollInKeep:(ctrl,user)=>{
 				if(opencount<1 || restart){
@@ -288,6 +328,20 @@ function _standby(prm){
 			},
 			OnEnd:(ctrl,user)=>{
 				halt=false;
+
+				if(ctrl.GetNextState()=='HEALTHY'){
+					try{
+						if(prm.OnRecover)prm.OnRecover(agent);
+					}
+					catch(e){
+						happen.HappenProp({
+							Class:'YgEs.AgentError',
+							Cause:'throw from a callback',
+							Src:GetInfo('OnRecover'),
+							Err:YgEs.FromError(e),
+						});
+					}
+				}
 			},
 		},
 	}

--- a/public/yges/ipl.js
+++ b/public/yges/ipl.js
@@ -1632,6 +1632,19 @@ function _standby(prm){
 			},
 		},
 		'TROUBLE':{
+			OnStart:(ctrl,user)=>{
+				try{
+					if(prm.OnTrouble)prm.OnTrouble(agent);
+				}
+				catch(e){
+					happen.HappenProp({
+						Class:'YgEs.AgentError',
+						Cause:'throw from a callback',
+						Src:GetInfo('OnTrouble'),
+						Err:YgEs.FromError(e),
+					});
+				}
+			},
 			OnPollInKeep:(ctrl,user)=>{
 				if(opencount<1 || restart){
 					ready=false;
@@ -1649,16 +1662,43 @@ function _standby(prm){
 					happen.HappenProp({
 							Class:'YgEs.AgentError',
 							Cause:'throw from a callback',
+						Src:GetInfo('OnPollInTrouble'),
+						Err:YgEs.FromError(e),
+					});
+					return 'HALT';
+				}
+			},
+			OnEnd:(ctrl,user)=>{
+				if(ctrl.GetNextState()=='HEALTHY'){
+					try{
+						if(prm.OnRecover)prm.OnRecover(agent);
+					}
+					catch(e){
+						happen.HappenProp({
+							Class:'YgEs.AgentError',
+							Cause:'throw from a callback',
 							Src:GetInfo('OnRecover'),
 							Err:YgEs.FromError(e),
 					});
-					return 'HALT';
+					}
 				}
 			},
 		},
 		'HALT':{
 			OnStart:(ctrl,user)=>{
 				halt=true;
+
+				try{
+					if(prm.OnHalt)prm.OnHalt(agent);
+				}
+				catch(e){
+					happen.HappenProp({
+						Class:'YgEs.AgentError',
+						Cause:'throw from a callback',
+						Src:GetInfo('OnHalt'),
+						Err:YgEs.FromError(e),
+					});
+				}
 			},
 			OnPollInKeep:(ctrl,user)=>{
 				if(opencount<1 || restart){
@@ -1670,6 +1710,20 @@ function _standby(prm){
 			},
 			OnEnd:(ctrl,user)=>{
 				halt=false;
+
+				if(ctrl.GetNextState()=='HEALTHY'){
+					try{
+						if(prm.OnRecover)prm.OnRecover(agent);
+					}
+					catch(e){
+						happen.HappenProp({
+							Class:'YgEs.AgentError',
+							Cause:'throw from a callback',
+							Src:GetInfo('OnRecover'),
+							Err:YgEs.FromError(e),
+						});
+					}
+				}
 			},
 		},
 	}


### PR DESCRIPTION
close #47

- OnTrouble
  - HEALTHY 状態から Happening 発生し、 TROUBLE に遷移
- OnHalt
  - TROUBLE 状態からさらに Happening 発生し、 HALT に遷移
  - TROUBLE 状態と違い、ポーリングを行わない
    - ポーリングを行う度に Happening インスタンスが増殖するリスクを回避するための措置
    - 解決するには、外部から Happening を読み取っての対処を要する
- OnRecover
  - TROUBLE,HALT 状態から HEALTHY への復帰
